### PR TITLE
feat: Default to Uptime tab for supports

### DIFF
--- a/src/lib/constants/classes.ts
+++ b/src/lib/constants/classes.ts
@@ -116,3 +116,9 @@ export const AP: Record<APTypes, [string, string]> = {
   enlightenment: ["Enlightenment", "text-sky-300"],
   leap: ["Leap", "text-lime-300"]
 };
+
+export const SUPPORT_CLASS_IDS: Set<number> = new Set([
+  classNameToClassId["Bard"],
+  classNameToClassId["Paladin"],
+  classNameToClassId["Artist"],
+]);

--- a/src/routes/(app)/logs/[id]/LogDamageMeter.svelte
+++ b/src/routes/(app)/logs/[id]/LogDamageMeter.svelte
@@ -32,6 +32,7 @@
   import LogSkillDetails from "./LogSkillDetails.svelte";
   import OpenerSkills from "./OpenerSkills.svelte";
   import UptimeDisplay from "$lib/components/UptimeDisplay.svelte";
+  import { SUPPORT_CLASS_IDS } from "$lib/constants/classes";
 
   let { encounter }: { encounter: Encounter } = $props();
 
@@ -52,8 +53,15 @@
 
   function inspectPlayer(name: string) {
     meterState = MeterState.PLAYER;
-    chartType = ChartType.SKILL_LOG;
     playerName = name;
+    const inspectedPlayer = encounter.entities[name];
+    if (inspectedPlayer && SUPPORT_CLASS_IDS.has(inspectedPlayer.classId)) {
+      tab = MeterTab.UPTIME;
+      chartType = ChartType.SKILL_LOG; // Or a new chart type for supports
+    } else {
+      tab = MeterTab.DAMAGE;
+      chartType = ChartType.SKILL_LOG;
+    }
     scrollToTop();
   }
 


### PR DESCRIPTION
When a player is inspected:
- If the player is a support class (Bard, Paladin, Artist), the default tab shown is now 'Uptime'.
- Otherwise (for DPS classes), the default tab remains 'Damage' (showing skill breakdowns).

This change enhances user experience by defaulting to the most relevant view based on player role, especially with the new Uptime Enhancer features.